### PR TITLE
Add configuration for precision

### DIFF
--- a/Resources/config/filters/sass.xml
+++ b/Resources/config/filters/sass.xml
@@ -10,6 +10,7 @@
         <parameter key="assetic.filter.sass.timeout">null</parameter>
         <parameter key="assetic.filter.sass.style">null</parameter>
         <parameter key="assetic.filter.sass.compass">null</parameter>
+        <parameter key="assetic.filter.sass.precision">null</parameter>
         <parameter key="assetic.filter.sass.load_paths" type="collection" />
     </parameters>
 
@@ -22,6 +23,7 @@
             <call method="setStyle"><argument>%assetic.filter.sass.style%</argument></call>
             <call method="setCompass"><argument>%assetic.filter.sass.compass%</argument></call>
             <call method="setLoadPaths"><argument>%assetic.filter.sass.load_paths%</argument></call>
+            <call method="setPrecision"><argument>%assetic.filter.sass.precision%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Now in assetic it's possible to set the precision of decimals
So we also need a way to set it in symfony which I think this is the correct way
The commit for assetic: https://github.com/kriswallsmith/assetic/commit/ec53b62cc24cde991062fa50798fe0b6436fd884