### PR TITLE
Fix asset dumping with assets added by the DI tag

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -45,7 +45,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
     public function dumpAsset($name, OutputInterface $stdout)
     {
         $asset = $this->am->get($name);
-        $formula = $this->am->getFormula($name);
+        $formula = $this->am->hasFormula($name) ? $this->am->getFormula($name) : array();
 
         // start by dumping the main asset
         $this->doDump($asset, $stdout);

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -124,6 +124,10 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
             ->with('test_asset')
             ->will($this->returnValue($asset));
         $this->am->expects($this->once())
+            ->method('hasFormula')
+            ->with('test_asset')
+            ->will($this->returnValue(true));
+        $this->am->expects($this->once())
             ->method('getFormula')
             ->with('test_asset')
             ->will($this->returnValue(array()));
@@ -161,6 +165,10 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with('test_asset')
             ->will($this->returnValue($asset));
+        $this->am->expects($this->once())
+            ->method('hasFormula')
+            ->with('test_asset')
+            ->will($this->returnValue(true));
         $this->am->expects($this->once())
             ->method('getFormula')
             ->with('test_asset')


### PR DESCRIPTION
When you add assets with the assetic.asset DI tag, the dump command fails because there is no formula corresponding to the asset.

This PR make the command work in this case by using an empty formula if the asset doesn't have one.