### PR TITLE
Cache key generation fix

### DIFF
--- a/Assetic/Filter/HashableFilter.php
+++ b/Assetic/Filter/HashableFilter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\Bundle\AsseticBundle\Assetic\Filter;
+
+use Assetic\Asset\AssetInterface;
+use Assetic\Filter\FilterInterface;
+use Assetic\Filter\HashableInterface;
+
+class HashableFilter implements FilterInterface, HashableInterface
+{
+
+    /**
+     * @var string
+     */
+    private $hash;
+
+    /**
+     * @param string $hash
+     */
+    public function __construct($hash)
+    {
+        $this->hash = $hash;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterLoad(AssetInterface $asset)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterDump(AssetInterface $asset)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hash()
+    {
+        return (string) $this->hash;
+    }
+}

--- a/Controller/AsseticController.php
+++ b/Controller/AsseticController.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Bundle\AsseticBundle\Assetic\Filter\HashableFilter;
 
 /**
  * Serves assets.
@@ -86,7 +87,7 @@ class AsseticController
             return $response;
         }
 
-        $response->setContent($this->cachifyAsset($asset)->dump());
+        $response->setContent($this->cachifyAsset($asset)->dump($this->createDumpFilter($asset, $lastModified)));
 
         return $response;
     }
@@ -108,6 +109,11 @@ class AsseticController
         }
 
         return $this;
+    }
+
+    protected function createDumpFilter(AssetInterface $asset, $calculatedLastModified = null)
+    {
+        return new HashableFilter($calculatedLastModified);
     }
 
     private function findAssetLeaf(\Traversable $asset, $pos)

--- a/Tests/Assetic/Filter/HashableFilterTest.php
+++ b/Tests/Assetic/Filter/HashableFilterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Assetic\Filter;
+
+use Symfony\Bundle\AsseticBundle\Assetic\Filter\HashableFilter;
+
+class HashableFilterTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider hashProvider
+     * @param $value
+     */
+    public function testHash($value)
+    {
+        $filter = new HashableFilter($value);
+        $this->assertEquals((string) $value, $filter->hash());
+    }
+
+    public static function hashProvider()
+    {
+        return array(
+            array(10),
+            array(99.99),
+            array('foo'),
+            array(true),
+            array(false),
+        );
+    }
+}


### PR DESCRIPTION
If you use a dependencies (e.g.: @import "foo.less") , then bad cache key is generated. Because it does not use the calculated modified date in controller. So the cache is not updated, if you change the child asset file.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~