### PR TITLE
Added configuration for ReactJsx filter support

### DIFF
--- a/DependencyInjection/AsseticExtension.php
+++ b/DependencyInjection/AsseticExtension.php
@@ -65,6 +65,7 @@ class AsseticExtension extends Extension
         $container->setParameter('assetic.node.paths', $config['node_paths']);
         $container->setParameter('assetic.ruby.bin', $config['ruby']);
         $container->setParameter('assetic.sass.bin', $config['sass']);
+        $container->setParameter('assetic.reactjsx.bin', $config['reactjsx']);
 
         // register formulae
         $formulae = array();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -71,6 +71,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('ruby')->defaultValue(function () use ($finder) { return $finder->find('ruby', '/usr/bin/ruby'); })->end()
                 ->scalarNode('sass')->defaultValue(function () use ($finder) { return $finder->find('sass', '/usr/bin/sass'); })->end()
+                ->scalarNode('reactjsx')->defaultValue(function () use ($finder) { return $finder->find('reactjsx', '/usr/bin/jsx'); })->end()
             ->end()
         ;
 

--- a/Resources/config/filters/reactjsx.xml
+++ b/Resources/config/filters/reactjsx.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.filter.reactjsx.class">Assetic\Filter\ReactJsxFilter</parameter>
+        <parameter key="assetic.filter.reactjsx.bin">%assetic.reactjsx.bin%</parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.filter.reactjsx" class="%assetic.filter.reactjsx.class%">
+            <tag name="assetic.filter" alias="reactjsx" />
+            <argument>%assetic.filter.reactjsx.bin%</argument>
+            <argument>%assetic.node.bin%</argument>
+        </service>
+    </services>
+</container>

--- a/Resources/config/schema/assetic-1.0.xsd
+++ b/Resources/config/schema/assetic-1.0.xsd
@@ -23,6 +23,7 @@
         <xsd:attribute name="java" type="xsd:string" />
         <xsd:attribute name="node" type="xsd:string" />
         <xsd:attribute name="sass" type="xsd:string" />
+        <xsd:attribute name="reactjsx" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="bundle">


### PR DESCRIPTION
Here is the required configuration to make the `ReactJsx` filter available through this bundle.

This filter is not present in any tagged version of Assetic yet though, so you guys might want to wait before merging this. I successfully tested this PR's contents on a fresh Standard Edition clone where I forced `kriswallsmith/assetic` to `dev-master`.