### PR TITLE
Resolve kernel.cache_dir parameter before writing routing.yml

### DIFF
--- a/DependencyInjection/Compiler/RouterResourcePass.php
+++ b/DependencyInjection/Compiler/RouterResourcePass.php
@@ -31,7 +31,8 @@ class RouterResourcePass implements CompilerPassInterface
             return;
         }
 
-        $file = $container->getParameter('kernel.cache_dir').'/assetic/routing.yml';
+        $cacheDir = $container->getParameterBag()->resolveValue($container->getParameter('kernel.cache_dir'));
+        $file = $cacheDir.'/assetic/routing.yml';
 
         if (!is_dir($dir = dirname($file))) {
             mkdir($dir, 0777, true);


### PR DESCRIPTION
The `kernel.cache_dir`-parameter is not resolved in *RouterResourcePass*. As a result of this, when other parameters are used to define this `kernel.cache_dir`, AsseticBundle generates its `routing.yml` file in the wrong directory, with `%parameter_name%`-subdirectories in its path. When handling requests, Symfony looks in the resolved cache directory, cannot find the routing file and throws an exception.

This patch makes sure the `kernel.cache_dir`-parameter is resolved before writing the `routing.yml` file, so the `routing.yml`-file ends up in the correct directory.