### PR TITLE
[Config] Treat NULL like "all bundles" (default behaviour)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -107,6 +107,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('bundles')
                     ->defaultValue($this->bundles)
+                    ->treatNullLike($this->bundles)
                     ->prototype('scalar')
                         ->validate()
                             ->ifNotInArray($this->bundles)


### PR DESCRIPTION
Allow to overwrite value with "all bundles" (default behaviour) for given enviroment.

Eg. if `config.yml` has `bundles: [DemoBundle]` and in `config_dev.yml` I want to overwrite that to "all bundles" (default) with this PR merged I could do that with `bundles: ~`.