### PR TITLE
Fix kriswallsmith/spork ProcessManager::__construct signature change

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -56,6 +56,7 @@ class DumpCommand extends AbstractCommand
 
             $this->spork = new ProcessManager(
                 new WrappedEventDispatcher($this->getContainer()->get('event_dispatcher')),
+                null,
                 $this->getContainer()->getParameter('kernel.debug')
             );
         }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         "symfony/dom-crawler": "~2.3",
         "symfony/css-selector": "~2.3"
     },
+    "conflict": {
+        "kriswallsmith/spork": "<=0.2"
+    },
     "suggest": {
         "symfony/twig-bundle": "to use the Twig integration",
         "kriswallsmith/spork": "to be able to dump assets in parallel"


### PR DESCRIPTION
Constructor signature change on `ProcessManager` since `0.3`: https://github.com/kriswallsmith/spork/blob/master/src/Spork/ProcessManager.php#L34

Just added a null parameter to constructor and set a conflict for `kriswallsmith/spork` `<=0.2`

New bugfix version is needed.