### PR TITLE
Remove usage of deprecated APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,25 @@ php:
     - hhvm
 
 matrix:
+    fast_finish: true
     include:
         - php: 5.3
-          env: deps=low
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.*@dev
+        - php: 5.6
+          env: SYMFONY_VERSION="3.0.x-dev as 2.8"
     allow_failures:
         - php: hhvm
-
-env:
-    global:
-        - deps=no
-
-before_install:
-    - composer self-update
+        - env: SYMFONY_VERSION=2.8.*@dev
+        - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
 install:
-    - if [ "$deps" = "no" ]; then composer --prefer-source install; fi;
-    - if [ "$deps" = "low" ]; then composer --prefer-source --prefer-lowest --prefer-stable update; fi;
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - composer update --prefer-source $COMPOSER_FLAGS
 
 script: phpunit -v

--- a/Controller/AsseticController.php
+++ b/Controller/AsseticController.php
@@ -34,9 +34,8 @@ class AsseticController
     protected $enableProfiler;
     protected $profiler;
 
-    public function __construct(Request $request, LazyAssetManager $am, CacheInterface $cache, $enableProfiler = false, Profiler $profiler = null)
+    public function __construct(LazyAssetManager $am, CacheInterface $cache, $enableProfiler = false, Profiler $profiler = null)
     {
-        $this->request = $request;
         $this->am = $am;
         $this->cache = $cache;
         $this->enableProfiler = (boolean) $enableProfiler;
@@ -48,7 +47,7 @@ class AsseticController
         trigger_error(sprintf('%s is deprecated. The values of asset variables are retrieved from the request after the route matching.', __METHOD__), E_USER_DEPRECATED);
     }
 
-    public function render($name, $pos = null)
+    public function render(Request $request, $name, $pos = null)
     {
         if (!$this->enableProfiler && null !== $this->profiler) {
             $this->profiler->disable();
@@ -66,7 +65,7 @@ class AsseticController
         $response = $this->createResponse();
         $response->setExpires(new \DateTime());
 
-        $this->configureAssetValues($asset);
+        $this->configureAssetValues($asset, $request);
 
         // last-modified
         if (null !== $lastModified = $this->am->getLastModified($asset)) {
@@ -82,7 +81,7 @@ class AsseticController
             $response->setETag(md5(serialize($formula)));
         }
 
-        if ($response->isNotModified($this->request)) {
+        if ($response->isNotModified($request)) {
             return $response;
         }
 
@@ -101,10 +100,10 @@ class AsseticController
         return new AssetCache($asset, $this->cache);
     }
 
-    protected function configureAssetValues(AssetInterface $asset)
+    protected function configureAssetValues(AssetInterface $asset, Request $request)
     {
         if ($vars = $asset->getVars()) {
-            $asset->setValues(array_intersect_key($this->request->attributes->all(), array_flip($vars)));
+            $asset->setValues(array_intersect_key($request->attributes->all(), array_flip($vars)));
         }
 
         return $this;

--- a/DependencyInjection/Compiler/StaticAsseticHelperPass.php
+++ b/DependencyInjection/Compiler/StaticAsseticHelperPass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class StaticAsseticHelperPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('assetic.helper.static')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('assetic.helper.static');
+
+        if (!method_exists($definition, 'setShared')
+            && $container->hasDefinition('templating.helper.assets')
+            && 'request' === $container->getDefinition('templating.helper.assets')->getScope()) {
+            $definition->setScope('request');
+        }
+    }
+}

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -18,8 +18,7 @@
             <argument type="service" id="assetic.asset_manager" />
             <argument>%assetic.variables%</argument>
         </service>
-        <service id="assetic.controller" class="%assetic.controller.class%" scope="prototype">
-            <argument type="service" id="request" />
+        <service id="assetic.controller" class="%assetic.controller.class%">
             <argument type="service" id="assetic.asset_manager" />
             <argument type="service" id="assetic.cache" />
             <argument>%assetic.enable_profiler%</argument>

--- a/Resources/config/templating_php.xml
+++ b/Resources/config/templating_php.xml
@@ -17,7 +17,7 @@
             <argument type="service" id="assetic.asset_factory" />
         </service>
 
-        <service id="assetic.helper.static" class="%assetic.helper.static.class%" scope="request">
+        <service id="assetic.helper.static" class="%assetic.helper.static.class%">
             <tag name="assetic.templating.php" />
             <argument type="service" id="templating.helper.assets" />
             <argument type="service" id="assetic.asset_factory" />

--- a/Templating/StaticAsseticHelper.php
+++ b/Templating/StaticAsseticHelper.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\AsseticBundle\Templating;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Factory\AssetFactory;
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 use Symfony\Component\Templating\Helper\CoreAssetsHelper;
 
 /**
@@ -27,11 +28,16 @@ class StaticAsseticHelper extends AsseticHelper
     /**
      * Constructor.
      *
-     * @param CoreAssetsHelper $assetsHelper The assets helper
+     * @param CoreAssetsHelper|AssetsHelper $assetsHelper The assets helper
      * @param AssetFactory     $factory      The asset factory
      */
-    public function __construct(CoreAssetsHelper $assetsHelper, AssetFactory $factory)
+    public function __construct($assetsHelper, AssetFactory $factory)
     {
+        // Symfony <2.7 BC
+        if (!$assetsHelper instanceof AssetsHelper && !$assetsHelper instanceof CoreAssetsHelper) {
+            throw new \InvalidArgumentException('Argument 1 passed to '.__METHOD__.' must be an instance of Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper or Symfony\Component\Templating\Helper\CoreAssetsHelper, instance of '.get_class($assetsHelper).' given');
+        }
+
         $this->assetsHelper = $assetsHelper;
 
         parent::__construct($factory);

--- a/Tests/Controller/AsseticControllerTest.php
+++ b/Tests/Controller/AsseticControllerTest.php
@@ -39,7 +39,7 @@ class AsseticControllerTest extends \PHPUnit_Framework_TestCase
             ->method('isMethodSafe')
             ->will($this->returnValue(true));
 
-        $this->controller = new AsseticController($this->request, $this->am, $this->cache);
+        $this->controller = new AsseticController($this->am, $this->cache);
     }
 
     public function testRenderNotFound()
@@ -53,7 +53,7 @@ class AsseticControllerTest extends \PHPUnit_Framework_TestCase
             ->with($name)
             ->will($this->returnValue(false));
 
-        $this->controller->render($name);
+        $this->controller->render($this->request, $name);
     }
 
     public function testRenderLastModifiedFresh()
@@ -86,7 +86,7 @@ class AsseticControllerTest extends \PHPUnit_Framework_TestCase
         $asset->expects($this->never())
             ->method('dump');
 
-        $response = $this->controller->render($name);
+        $response = $this->controller->render($this->request, $name);
 
         $this->assertEquals(304, $response->getStatusCode(), '->render() sends a Not Modified response when If-Modified-Since is fresh');
     }
@@ -127,7 +127,7 @@ class AsseticControllerTest extends \PHPUnit_Framework_TestCase
             ->method('dump')
             ->will($this->returnValue($content));
 
-        $response = $this->controller->render($name);
+        $response = $this->controller->render($this->request, $name);
 
         $this->assertEquals(200, $response->getStatusCode(), '->render() sends an OK response when If-Modified-Since is stale');
         $this->assertEquals($content, $response->getContent(), '->render() sends the dumped asset as the response content');
@@ -166,7 +166,7 @@ class AsseticControllerTest extends \PHPUnit_Framework_TestCase
         $asset->expects($this->never())
             ->method('dump');
 
-        $response = $this->controller->render($name);
+        $response = $this->controller->render($this->request, $name);
 
         $this->assertEquals(304, $response->getStatusCode(), '->render() sends a Not Modified response when If-None-Match is fresh');
     }
@@ -205,7 +205,7 @@ class AsseticControllerTest extends \PHPUnit_Framework_TestCase
             ->method('dump')
             ->will($this->returnValue($content));
 
-        $response = $this->controller->render($name);
+        $response = $this->controller->render($this->request, $name);
 
         $this->assertEquals(200, $response->getStatusCode(), '->render() sends an OK response when If-None-Match is stale');
         $this->assertEquals($content, $response->getContent(), '->render() sends the dumped asset as the response content');

--- a/Tests/DependencyInjection/AsseticExtensionTest.php
+++ b/Tests/DependencyInjection/AsseticExtensionTest.php
@@ -55,7 +55,13 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $this->container = new ContainerBuilder();
         $this->container->addScope(new Scope('request'));
         $this->container->register('request', 'Symfony\\Component\\HttpFoundation\\Request')->setScope('request');
-        $this->container->register('templating.helper.assets', $this->getMockClass('Symfony\\Component\\Templating\\Helper\\AssetsHelper'));
+        // Symfony <2.7 BC
+        if (class_exists('Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\AssetsHelper')) {
+            $this->container->register('templating.helper.assets', $this->getMockClass('Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\AssetsHelper'))
+                ->addArgument(new Definition($this->getMockClass('Symfony\\Component\\Asset\\Packages')));
+        } else {
+            $this->container->register('templating.helper.assets', $this->getMockClass('Symfony\\Component\\Templating\\Helper\\AssetsHelper'));
+        }
         $this->container->register('templating.helper.router', $this->getMockClass('Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\RouterHelper'))
             ->addArgument(new Definition($this->getMockClass('Symfony\\Component\\Routing\\RouterInterface')));
         $this->container->register('twig', 'Twig_Environment');

--- a/Tests/DependencyInjection/AsseticExtensionTest.php
+++ b/Tests/DependencyInjection/AsseticExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\AsseticBundle\Tests\DependencyInjection;
 
 use Symfony\Bundle\AsseticBundle\DependencyInjection\AsseticExtension;
+use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\AsseticControllerPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\CheckClosureFilterPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\CheckYuiFilterPass;
 use Symfony\Component\DependencyInjection\Container;
@@ -53,8 +54,11 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
 
         $this->container = new ContainerBuilder();
-        $this->container->addScope(new Scope('request'));
-        $this->container->register('request', 'Symfony\\Component\\HttpFoundation\\Request')->setScope('request');
+        // Symfony 2.3 BC
+        if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'setShared')) {
+            $this->container->addScope(new Scope('request'));
+            $this->container->register('request', 'Symfony\\Component\\HttpFoundation\\Request')->setScope('request');
+        }
         // Symfony <2.7 BC
         if (class_exists('Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\AssetsHelper')) {
             $this->container->register('templating.helper.assets', $this->getMockClass('Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\AssetsHelper'))
@@ -257,8 +261,11 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         eval('?>'.$dumper->dump(array('class' => $class)));
 
         $container = new $class();
-        $container->enterScope('request');
-        $container->set('request', Request::create('/'));
+        // Symfony 2.3 BC
+        if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'setShared')) {
+            $container->enterScope('request');
+            $container->set('request', Request::create('/'));
+        }
         $container->set('kernel', $this->kernel);
 
         return $container;

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "psr-4": { "Symfony\\Bundle\\AsseticBundle\\": "" }
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.6-dev"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/twig-bundle": "~2.3",
         "symfony/class-loader": "~2.3",
         "symfony/dom-crawler": "~2.3",
-        "symfony/css-selector": "~2.3"
+        "symfony/css-selector": "~2.3",
+        "symfony/phpunit-bridge": "~2.7"
     },
     "conflict": {
         "kriswallsmith/spork": "<=0.2"


### PR DESCRIPTION
This is a WIP to try fixing deprecations errors.

For the moment, I just added phpunit-bridge and improve Travis to test multiples version of Symfony.