### PR TITLE
Add support for Twig 2

### DIFF
--- a/Twig/AsseticNode.php
+++ b/Twig/AsseticNode.php
@@ -59,8 +59,7 @@ class AsseticNode extends BaseAsseticNode
         }
 
         return new \Twig_Node_Expression_Function(
-            version_compare(\Twig_Environment::VERSION, '1.2.0-DEV', '<')
-                ? new \Twig_Node_Expression_Name('path', $this->getLine()) : 'path',
+            'path',
             new \Twig_Node($nodes),
             $this->getLine()
         );
@@ -75,8 +74,7 @@ class AsseticNode extends BaseAsseticNode
         }
 
         return new \Twig_Node_Expression_Function(
-            version_compare(\Twig_Environment::VERSION, '1.2.0-DEV', '<')
-                ? new \Twig_Node_Expression_Name('asset', $this->getLine()) : 'asset',
+            'asset',
             new \Twig_Node($arguments),
             $this->getLine()
         );

--- a/Twig/AsseticTokenParser.php
+++ b/Twig/AsseticTokenParser.php
@@ -63,6 +63,11 @@ class AsseticTokenParser extends BaseAsseticTokenParser
         return parent::parse($token);
     }
 
+    protected function createBodyNode(AssetInterface $asset, \Twig_Node $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
+    {
+        return new AsseticNode($asset, $body, $inputs, $filters, $name, $attributes, $lineno, $tag);
+    }
+
     protected function createNode(AssetInterface $asset, \Twig_NodeInterface $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
     {
         return new AsseticNode($asset, $body, $inputs, $filters, $name, $attributes, $lineno, $tag);

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/phpunit-bridge": "~2.7"
     },
     "conflict": {
+        "twig/twig": "<1.20",
         "kriswallsmith/spork": "<=0.2"
     },
     "suggest": {


### PR DESCRIPTION
This depends on https://github.com/kriswallsmith/assetic/pull/751for the TokenParser change (but the bundle is still compatible with older versions of Assetic not implementing this change, and current versions of the bundle are compatible with Assetic with the change applied thanks to BC layers)